### PR TITLE
Move definition of value to avoid scope issue

### DIFF
--- a/Improved Zigbee Hue MA.groovy
+++ b/Improved Zigbee Hue MA.groovy
@@ -185,12 +185,13 @@ def parse(String description) {
     }
     else {
         def name = description?.startsWith("on/off: ") ? "switch" : null
+		def value = null
         if (name == "switch") {
-            def value = (description?.endsWith(" 1") ? "on" : "off")
+            value = (description?.endsWith(" 1") ? "on" : "off")
         	log.debug value
             sendEvent(name: "switchColor", value: (value == "off" ? "off" : device.currentValue("colorName")), displayed: false)
         }
-        else { def value = null }
+        else { value = null }
         def result = createEvent(name: name, value: value)
         log.debug "Parse returned ${result?.descriptionText}"
         return result


### PR DESCRIPTION
Was seeing Switch value set to null when on/off messages were coming
from an Osram RGBW bulb.
