### PR TITLE
Correct scope of value variable

### DIFF
--- a/devicetypes/sticks18/dresden-fls-pp.src/dresden-fls-pp.groovy
+++ b/devicetypes/sticks18/dresden-fls-pp.src/dresden-fls-pp.groovy
@@ -197,13 +197,14 @@ def parse(String description) {
         }
     }
     else {
-        def name = description?.startsWith("on/off: ") ? "switch" : null
+        def name = description?.startsWith("on/off: ") ? "switch" : "unknown"
+	def value = null
         if (name == "switch") {
-            def value = (description?.endsWith(" 1") ? "on" : "off")
+            value = (description?.endsWith(" 1") ? "on" : "off")
         	log.debug value
             sendEvent(name: "switchColor", value: (value == "off" ? "off" : device.currentValue("colorName")), displayed: false)
         }
-        else { def value = null }
+        else { value = null }
         def result = createEvent(name: name, value: value)
         log.debug "Parse returned ${result?.descriptionText}"
         return result


### PR DESCRIPTION
@sticks18 
The scope of `value` was incorrect, thus leading to incorrect "empty" values.